### PR TITLE
Fix: setting buffertools to an empty object

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "standard && tap test/*.js --coverage"
   },
+  "browser": {
+    "buffertools": false
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/othiym23/only-shallow.git"


### PR DESCRIPTION
I want to make node-tap browserifyable because I enjoy using it so much.